### PR TITLE
Add .gitignore to exclude files for future use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Node modules for both frontend and backend
+node_modules/
+
+# Environment variables
+.env
+.env.local
+
+# Build output
+dist/
+build/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+logs/
+*.log
+
+# Prisma generated files
+prisma/dev.db
+prisma/dev.db-journal
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDEs and Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Optional: Uploaded files (if used later)
+server/uploads/
+
+# Optional: coverage reports
+coverage/
+*.lcov


### PR DESCRIPTION
Closes #1 
Added a `.gitignore` file to the project to prevent unnecessary or sensitive files from being tracked by Git. While currently it only excludes the `.env` file, this setup will help avoid accidental commits of environment variables and can be extended in the future as the project grows (e.g., node_modules, log files, build outputs, etc.).

This is a preventive step to maintain a clean and secure repository structure moving forward.


Also @Abhinavhaldiya  can you add label 1 to this, and i will create more issues and work on the projects